### PR TITLE
NUA-27: Implement the Resume page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ next-env.d.ts
 
 # Environment Variables
 .env*
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "eslint-config-next": "14.2.7",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
+        "next-test-api-route-handler": "^4.0.8",
         "ts-node": "^10.9.2",
         "typescript": "^5"
       }
@@ -1381,6 +1382,13 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kamilkisiela/fast-url-parser": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@kamilkisiela/fast-url-parser/-/fast-url-parser-1.1.4.tgz",
+      "integrity": "sha512-gbkePEBupNydxCelHCESvFSFM8XPh1Zs/OAVRW/rKpEqPAl5PbOM90Si8mv9bvnR53uPD2s/FiRxdvSejpRJew==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@next/env": {
       "version": "14.2.7",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.7.tgz",
@@ -2117,6 +2125,50 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
+    },
+    "node_modules/@whatwg-node/fetch": {
+      "version": "0.9.21",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/fetch/-/fetch-0.9.21.tgz",
+      "integrity": "sha512-Wt0jPb+04JjobK0pAAN7mEHxVHcGA9HoP3OyCsZtyAecNQeADXCZ1MihFwVwjsgaRYuGVmNlsCmLxlG6mor8Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@whatwg-node/node-fetch": "^0.5.23",
+        "urlpattern-polyfill": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@whatwg-node/node-fetch": {
+      "version": "0.5.26",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/node-fetch/-/node-fetch-0.5.26.tgz",
+      "integrity": "sha512-4jXDeZ4IH4bylZ6wu14VEx0aDXXhrN4TC279v9rPmn08g4EYekcYf8wdcOOnS9STjDkb6x77/6xBUTqxGgjr8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@kamilkisiela/fast-url-parser": "^1.1.4",
+        "busboy": "^1.6.0",
+        "fast-querystring": "^1.1.1",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@whatwg-node/server": {
+      "version": "0.9.49",
+      "resolved": "https://registry.npmjs.org/@whatwg-node/server/-/server-0.9.49.tgz",
+      "integrity": "sha512-3KzLXw80gWnTsQ746G/LFdCThTPfDodjQs4PnmoNuPa6XUOl4HWq8TlJpxtmnEEB+y+UYLal+3VQ68dtYlbUDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@whatwg-node/fetch": "^0.9.21",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/abab": {
       "version": "2.0.6",
@@ -2948,6 +3000,28 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
+    },
+    "node_modules/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/core-js": {
+      "version": "3.38.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.38.1.tgz",
+      "integrity": "sha512-OP35aUorbU3Zvlx7pjsFdu1rGNnD4pgw/CWoYzRY3t2EzoVT7shKHY1dlAy3f41cGIO7ZDPQimhGFTlEYkG/Hw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
@@ -4076,6 +4150,13 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/fast-decode-uri-component": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
+      "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4121,6 +4202,16 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
+    },
+    "node_modules/fast-querystring": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
+      "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-decode-uri-component": "^1.0.1"
+      }
     },
     "node_modules/fastq": {
       "version": "1.17.1",
@@ -6658,6 +6749,24 @@
         }
       }
     },
+    "node_modules/next-test-api-route-handler": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/next-test-api-route-handler/-/next-test-api-route-handler-4.0.8.tgz",
+      "integrity": "sha512-eCGT/axiz6w7JqkT+L2gfekrx1+I5Uq+TSoB2U3lLpdlNehDtF6bd4hiHwXX4/SvdUjBL8g38Wfaylm9FJ+h2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@whatwg-node/server": "^0.9.34",
+        "cookie": "^0.6.0",
+        "core-js": "^3.37.1"
+      },
+      "engines": {
+        "node": "^18.18.2 || ^20.10.0 || >=21.2.0"
+      },
+      "peerDependencies": {
+        "next": ">=9"
+      }
+    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -7136,7 +7245,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -8476,6 +8584,13 @@
         "querystringify": "^2.1.1",
         "requires-port": "^1.0.0"
       }
+    },
+    "node_modules/urlpattern-polyfill": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/urlpattern-polyfill/-/urlpattern-polyfill-10.0.0.tgz",
+      "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,11 @@
       "name": "my-site",
       "version": "0.1.0",
       "dependencies": {
+        "@fortawesome/fontawesome-svg-core": "^6.6.0",
+        "@fortawesome/free-brands-svg-icons": "^6.6.0",
+        "@fortawesome/free-regular-svg-icons": "^6.6.0",
+        "@fortawesome/free-solid-svg-icons": "^6.6.0",
+        "@fortawesome/react-fontawesome": "^0.2.2",
         "next": "14.2.7",
         "nodemailer": "^6.9.15",
         "react": "^18",
@@ -737,6 +742,76 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.6.0.tgz",
+      "integrity": "sha512-xyX0X9mc0kyz9plIyryrRbl7ngsA9jz77mCZJsUkLl+ZKs0KWObgaEBoSgQiYWAsSmjz/yjl0F++Got0Mdp4Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.6.0.tgz",
+      "integrity": "sha512-KHwPkCk6oRT4HADE7smhfsKudt9N/9lm6EJ5BVg0tD1yPA5hht837fB87F8pn15D8JfTqQOjhKTktwmLMiD7Kg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.6.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-brands-svg-icons": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-brands-svg-icons/-/free-brands-svg-icons-6.6.0.tgz",
+      "integrity": "sha512-1MPD8lMNW/earme4OQi1IFHtmHUwAKgghXlNwWi9GO7QkTfD+IIaYpIai4m2YJEzqfEji3jFHX1DZI5pbY/biQ==",
+      "license": "(CC-BY-4.0 AND MIT)",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.6.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-regular-svg-icons": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-regular-svg-icons/-/free-regular-svg-icons-6.6.0.tgz",
+      "integrity": "sha512-Yv9hDzL4aI73BEwSEh20clrY8q/uLxawaQ98lekBx6t9dQKDHcDzzV1p2YtBGTtolYtNqcWdniOnhzB+JPnQEQ==",
+      "license": "(CC-BY-4.0 AND MIT)",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.6.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.6.0.tgz",
+      "integrity": "sha512-IYv/2skhEDFc2WGUcqvFJkeK39Q+HyPf5GHUrT/l2pKbtgEIv1al1TKd6qStR5OIwQdN1GZP54ci3y4mroJWjA==",
+      "license": "(CC-BY-4.0 AND MIT)",
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.6.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.2.tgz",
+      "integrity": "sha512-EnkrprPNqI6SXJl//m29hpaNzOp1bruISWaOiRtkMi/xSvHJlzc2j2JAYS7egxt/EbjSNV/k6Xy0AQI6vB2+1g==",
+      "license": "MIT",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+        "react": ">=16.3"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -6617,7 +6692,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7103,7 +7177,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -7193,8 +7266,7 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/readdirp": {
       "version": "3.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "sass": "^1.77.8"
       },
       "devDependencies": {
+        "@playwright/test": "^1.47.0",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.5.0",
         "@testing-library/react": "^16.0.1",
@@ -1581,6 +1582,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.47.0.tgz",
+      "integrity": "sha512-SgAdlSwYVpToI4e/IH19IHHWvoijAYH5hu2MWSXptRypLSnzj51PcGD+rsOXFayde4P9ZLi+loXVwArg6IUkCA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.47.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rushstack/eslint-patch": {
@@ -7081,6 +7098,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.47.0.tgz",
+      "integrity": "sha512-jOWiRq2pdNAX/mwLiwFYnPHpEZ4rM+fRSQpRHwEwZlP2PUANvL3+aJOF/bvISMhFD30rqMxUB4RJx9aQbfh4Ww==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.47.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.47.0.tgz",
+      "integrity": "sha512-1DyHT8OqkcfCkYUD9zzUTfg7EfTd+6a8MkD/NWOvjo0u/SCNd5YmY/lJwFvUZOxJbWNds+ei7ic2+R/cRz/PDg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,11 @@
     "test": "jest --watchAll"
   },
   "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "^6.6.0",
+    "@fortawesome/free-brands-svg-icons": "^6.6.0",
+    "@fortawesome/free-regular-svg-icons": "^6.6.0",
+    "@fortawesome/free-solid-svg-icons": "^6.6.0",
+    "@fortawesome/react-fontawesome": "^0.2.2",
     "next": "14.2.7",
     "nodemailer": "^6.9.15",
     "react": "^18",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "eslint-config-next": "14.2.7",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
+    "next-test-api-route-handler": "^4.0.8",
     "ts-node": "^10.9.2",
     "typescript": "^5"
   }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "sass": "^1.77.8"
   },
   "devDependencies": {
+    "@playwright/test": "^1.47.0",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.5.0",
     "@testing-library/react": "^16.0.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "jest --watchAll"
+    "test": "NODE_ENV=development jest --watchAll"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.6.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,78 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// import dotenv from 'dotenv';
+// dotenv.config({ path: path.resolve(__dirname, '.env') });
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './tests',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    // baseURL: 'http://127.0.0.1:3000',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  // webServer: {
+  //   command: 'npm run start',
+  //   url: 'http://127.0.0.1:3000',
+  //   reuseExistingServer: !process.env.CI,
+  // },
+});

--- a/src/app/__snapshots__/page.test.tsx.snap
+++ b/src/app/__snapshots__/page.test.tsx.snap
@@ -320,9 +320,12 @@ exports[`<Home/> Test Suite should render the <Home/> component unchanged 1`] = 
       <div
         style="display: flex; justify-content: center; margin: 3rem 0px 3rem 0px; text-decoration: underline;"
       >
-        <h4>
+        <a
+          class="Link"
+          href="/resume"
+        >
           See my full resume
-        </h4>
+        </a>
       </div>
     </section>
     <section

--- a/src/app/api/email/route.ts
+++ b/src/app/api/email/route.ts
@@ -17,7 +17,10 @@ export async function POST(request: Request) {
   });
   console.log("Message sent: %s", info.messageId);
   return NextResponse.json(
-    { message: "Successfully exported the resume to a PDF file" },
+    {
+      message:
+        "Successfully sent the contact form to the defined email address",
+    },
     { status: 201 },
   );
 }

--- a/src/app/api/email/route.ts
+++ b/src/app/api/email/route.ts
@@ -1,3 +1,4 @@
+import { NextResponse } from "next/server";
 import { transporter } from "../../lib/nodemailer/nodemailerConfig";
 
 export async function POST(request: Request) {
@@ -15,5 +16,8 @@ export async function POST(request: Request) {
     html: `<p>Hello,<p><br><p>You received a message with the following information: </p><ul><li>First Name: ${firstName}</li><li>Last Name: ${lastName}</li><li>Email: ${email}</li><li>Phone: ${phone}</li><li>Message: ${message}</li></ul>`,
   });
   console.log("Message sent: %s", info.messageId);
-  return Response.json({ firstName, lastName, email, phone, message });
+  return NextResponse.json(
+    { message: "Successfully exported the resume to a PDF file" },
+    { status: 201 },
+  );
 }

--- a/src/app/api/resume/route.test.ts
+++ b/src/app/api/resume/route.test.ts
@@ -5,10 +5,11 @@
 import { testApiHandler } from "next-test-api-route-handler";
 import * as appHandler from "./route";
 import fs from "fs";
+import { RESUME_FILENAME } from "@/app/utils/constants";
 
 describe("Resume API Routes (/api/resume) Test Suite", () => {
   afterAll(() => {
-    fs.unlinkSync("Resume_Jean_Frederic_Mainville.pdf");
+    fs.unlinkSync(RESUME_FILENAME);
   });
 
   it("should export all the pages of the Resume page to a PDF file", async () => {

--- a/src/app/api/resume/route.test.ts
+++ b/src/app/api/resume/route.test.ts
@@ -1,0 +1,26 @@
+/**
+ * @jest-environment node
+ */
+
+import { testApiHandler } from "next-test-api-route-handler";
+import * as appHandler from "./route";
+import fs from "fs";
+
+describe("Resume API Routes (/api/resume) Test Suite", () => {
+  afterAll(() => {
+    fs.unlinkSync("Resume_Jean_Frederic_Mainville.pdf");
+  });
+
+  it("should export all the pages of the Resume page to a PDF file", async () => {
+    await testApiHandler({
+      appHandler,
+      requestPatcher(request) {
+        request.headers.set("host", "localhost:3000");
+      },
+      async test({ fetch }) {
+        const res = await fetch({ method: "GET" });
+        expect(res.status).toBe(201);
+      },
+    });
+  });
+});

--- a/src/app/api/resume/route.ts
+++ b/src/app/api/resume/route.ts
@@ -1,0 +1,18 @@
+import { chromium } from "@playwright/test";
+
+export async function POST(request: Request) {
+  const hostname = request.headers.get("host");
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  const page = await context.newPage();
+  await page.goto(
+    `${process.env.NODE_ENV === "development" ? "http" : "https"}://${hostname}/resume`,
+  );
+  await page.emulateMedia({ media: "print" });
+  await page.pdf({
+    path: "Resume_Jean_Frederic_Mainville.pdf",
+    printBackground: true,
+  });
+  await browser.close();
+  return Response.json({});
+}

--- a/src/app/api/resume/route.ts
+++ b/src/app/api/resume/route.ts
@@ -1,3 +1,4 @@
+import { NextResponse } from "next/server";
 import { chromium } from "@playwright/test";
 
 export async function POST(request: Request) {
@@ -14,5 +15,8 @@ export async function POST(request: Request) {
     printBackground: true,
   });
   await browser.close();
-  return Response.json({});
+  return NextResponse.json(
+    { message: "Successfully exported the resume to a PDF file" },
+    { status: 201 },
+  );
 }

--- a/src/app/api/resume/route.ts
+++ b/src/app/api/resume/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { chromium } from "@playwright/test";
 
 export async function POST(request: Request) {
-  const hostname = request.headers.get("host");
+  const hostname: string | null = request.headers.get("host");
   const browser = await chromium.launch();
   const context = await browser.newContext();
   const page = await context.newPage();

--- a/src/app/api/resume/route.ts
+++ b/src/app/api/resume/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { chromium } from "@playwright/test";
 import fs from "fs";
 import path from "path";
+import { RESUME_FILENAME } from "@/app/utils/constants";
 
 export async function GET(request: Request) {
   const hostname: string | null = request.headers.get("host");
@@ -13,17 +14,17 @@ export async function GET(request: Request) {
   );
   await page.emulateMedia({ media: "print" });
   await page.pdf({
-    path: "./Resume_Jean_Frederic_Mainville.pdf",
+    path: `./${RESUME_FILENAME}`,
     printBackground: true,
   });
 
   await browser.close();
-  const filePath = path.resolve(".", "Resume_Jean_Frederic_Mainville.pdf");
+  const filePath = path.resolve(".", RESUME_FILENAME);
   const pdfFile = fs.readFileSync(filePath);
   return new NextResponse(pdfFile, {
     status: 201,
     headers: new Headers({
-      "Content-Disposition": `attachment; filename=Resume_Jean_Frederic_Mainville.pdf`,
+      "Content-Disposition": `attachment; filename=${RESUME_FILENAME}`,
       "Content-Type": "application/pdf",
       "Content-Length": pdfFile.length.toString(),
     }),

--- a/src/app/api/resume/route.ts
+++ b/src/app/api/resume/route.ts
@@ -1,7 +1,9 @@
 import { NextResponse } from "next/server";
 import { chromium } from "@playwright/test";
+import fs from "fs";
+import path from "path";
 
-export async function POST(request: Request) {
+export async function GET(request: Request) {
   const hostname: string | null = request.headers.get("host");
   const browser = await chromium.launch();
   const context = await browser.newContext();
@@ -11,12 +13,19 @@ export async function POST(request: Request) {
   );
   await page.emulateMedia({ media: "print" });
   await page.pdf({
-    path: "Resume_Jean_Frederic_Mainville.pdf",
+    path: "./Resume_Jean_Frederic_Mainville.pdf",
     printBackground: true,
   });
+
   await browser.close();
-  return NextResponse.json(
-    { message: "Successfully exported the resume to a PDF file" },
-    { status: 201 },
-  );
+  const filePath = path.resolve(".", "Resume_Jean_Frederic_Mainville.pdf");
+  const pdfFile = fs.readFileSync(filePath);
+  return new NextResponse(pdfFile, {
+    status: 201,
+    headers: new Headers({
+      "Content-Disposition": `attachment; filename=Resume_Jean_Frederic_Mainville.pdf`,
+      "Content-Type": "application/pdf",
+      "Content-Length": pdfFile.length.toString(),
+    }),
+  });
 }

--- a/src/app/components/Experience/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/Experience/__snapshots__/index.test.tsx.snap
@@ -235,9 +235,12 @@ exports[`<Experience/> Test Suite should render the <Experience/> component unch
     <div
       style="display: flex; justify-content: center; margin: 3rem 0px 3rem 0px; text-decoration: underline;"
     >
-      <h4>
+      <a
+        class="Link"
+        href="/resume"
+      >
         See my full resume
-      </h4>
+      </a>
     </div>
   </section>
 </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -99,7 +99,7 @@ body {
 a {
   color: inherit;
   text-decoration: none;
-  font-size: 24px;
+  font-size: 16px;
   line-height: 1.2;
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -40,7 +40,7 @@
   --card-border-rgb: 131, 134, 135;
 }
 
-@media (prefers-color-scheme: dark) {
+@media (prefers-color-scheme: light) {
   :root {
     --foreground-rgb: 255, 255, 255;
     --background-start-rgb: 0, 0, 0;
@@ -103,9 +103,9 @@ a {
   line-height: 1.2;
 }
 
-@media (prefers-color-scheme: dark) {
+@media (prefers-color-scheme: light) {
   html {
-    color-scheme: dark;
+    color-scheme: light;
   }
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -40,7 +40,7 @@
   --card-border-rgb: 131, 134, 135;
 }
 
-@media (prefers-color-scheme: light) {
+@media (prefers-color-scheme: dark) {
   :root {
     --foreground-rgb: 255, 255, 255;
     --background-start-rgb: 0, 0, 0;
@@ -103,9 +103,9 @@ a {
   line-height: 1.2;
 }
 
-@media (prefers-color-scheme: light) {
+@media (prefers-color-scheme: dark) {
   html {
-    color-scheme: light;
+    color-scheme: dark;
   }
 }
 

--- a/src/app/resume/__snapshots__/page.test.tsx.snap
+++ b/src/app/resume/__snapshots__/page.test.tsx.snap
@@ -220,10 +220,12 @@ exports[`<Resume/> Test Suite should render the <Resume/> page unchanged 1`] = `
         >
           Back to the home page
         </a>
-        <div
-          class="PdfExportButton"
-        >
-          Export to PDF
+        <div>
+          <button
+            class="PdfExportButton"
+          >
+            Export to PDF
+          </button>
         </div>
       </div>
       <div

--- a/src/app/resume/__snapshots__/page.test.tsx.snap
+++ b/src/app/resume/__snapshots__/page.test.tsx.snap
@@ -213,13 +213,16 @@ exports[`<Resume/> Test Suite should render the <Resume/> page unchanged 1`] = `
     >
       <div
         class="Navigation"
+        id="Navigation"
       >
         <a
           href="/"
         >
           Back to the home page
         </a>
-        <div>
+        <div
+          class="PdfExportButton"
+        >
           Export to PDF
         </div>
       </div>

--- a/src/app/resume/__snapshots__/page.test.tsx.snap
+++ b/src/app/resume/__snapshots__/page.test.tsx.snap
@@ -1,0 +1,549 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Resume/> Test Suite should render the <Resume/> page unchanged 1`] = `
+<div>
+  <section
+    class="Main"
+  >
+    <div
+      class="Sidebar"
+    >
+      <div
+        class="Contact"
+      >
+        <h2>
+          Contact
+        </h2>
+        <div
+          class="ContactEntry"
+        >
+          <svg
+            aria-hidden="true"
+            class="svg-inline--fa fa-globe "
+            data-icon="globe"
+            data-prefix="fas"
+            focusable="false"
+            height="20"
+            role="img"
+            viewBox="0 0 512 512"
+            width="20"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M352 256c0 22.2-1.2 43.6-3.3 64l-185.3 0c-2.2-20.4-3.3-41.8-3.3-64s1.2-43.6 3.3-64l185.3 0c2.2 20.4 3.3 41.8 3.3 64zm28.8-64l123.1 0c5.3 20.5 8.1 41.9 8.1 64s-2.8 43.5-8.1 64l-123.1 0c2.1-20.6 3.2-42 3.2-64s-1.1-43.4-3.2-64zm112.6-32l-116.7 0c-10-63.9-29.8-117.4-55.3-151.6c78.3 20.7 142 77.5 171.9 151.6zm-149.1 0l-176.6 0c6.1-36.4 15.5-68.6 27-94.7c10.5-23.6 22.2-40.7 33.5-51.5C239.4 3.2 248.7 0 256 0s16.6 3.2 27.8 13.8c11.3 10.8 23 27.9 33.5 51.5c11.6 26 20.9 58.2 27 94.7zm-209 0L18.6 160C48.6 85.9 112.2 29.1 190.6 8.4C165.1 42.6 145.3 96.1 135.3 160zM8.1 192l123.1 0c-2.1 20.6-3.2 42-3.2 64s1.1 43.4 3.2 64L8.1 320C2.8 299.5 0 278.1 0 256s2.8-43.5 8.1-64zM194.7 446.6c-11.6-26-20.9-58.2-27-94.6l176.6 0c-6.1 36.4-15.5 68.6-27 94.6c-10.5 23.6-22.2 40.7-33.5 51.5C272.6 508.8 263.3 512 256 512s-16.6-3.2-27.8-13.8c-11.3-10.8-23-27.9-33.5-51.5zM135.3 352c10 63.9 29.8 117.4 55.3 151.6C112.2 482.9 48.6 426.1 18.6 352l116.7 0zm358.1 0c-30 74.1-93.6 130.9-171.9 151.6c25.5-34.2 45.2-87.7 55.3-151.6l116.7 0z"
+              fill="currentColor"
+            />
+          </svg>
+          <p
+            class="ContactEntryText"
+          >
+            <a
+              href="https://jfmainville.me"
+            >
+              My Site
+            </a>
+          </p>
+        </div>
+        <div
+          class="ContactEntry"
+        >
+          <svg
+            aria-hidden="true"
+            class="svg-inline--fa fa-envelope "
+            data-icon="envelope"
+            data-prefix="far"
+            focusable="false"
+            height="20"
+            role="img"
+            viewBox="0 0 512 512"
+            width="20"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M64 112c-8.8 0-16 7.2-16 16l0 22.1L220.5 291.7c20.7 17 50.4 17 71.1 0L464 150.1l0-22.1c0-8.8-7.2-16-16-16L64 112zM48 212.2L48 384c0 8.8 7.2 16 16 16l384 0c8.8 0 16-7.2 16-16l0-171.8L322 328.8c-38.4 31.5-93.7 31.5-132 0L48 212.2zM0 128C0 92.7 28.7 64 64 64l384 0c35.3 0 64 28.7 64 64l0 256c0 35.3-28.7 64-64 64L64 448c-35.3 0-64-28.7-64-64L0 128z"
+              fill="currentColor"
+            />
+          </svg>
+          <p
+            class="ContactEntryText"
+          >
+            <a
+              href="mailto:jfmainville@outlook.com"
+            >
+              Email
+            </a>
+          </p>
+        </div>
+        <div
+          class="ContactEntry"
+        >
+          <svg
+            aria-hidden="true"
+            class="svg-inline--fa fa-linkedin "
+            data-icon="linkedin"
+            data-prefix="fab"
+            focusable="false"
+            height="20"
+            role="img"
+            viewBox="0 0 448 512"
+            width="20"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M416 32H31.9C14.3 32 0 46.5 0 64.3v383.4C0 465.5 14.3 480 31.9 480H416c17.6 0 32-14.5 32-32.3V64.3c0-17.8-14.4-32.3-32-32.3zM135.4 416H69V202.2h66.5V416zm-33.2-243c-21.3 0-38.5-17.3-38.5-38.5S80.9 96 102.2 96c21.2 0 38.5 17.3 38.5 38.5 0 21.3-17.2 38.5-38.5 38.5zm282.1 243h-66.4V312c0-24.8-.5-56.7-34.5-56.7-34.6 0-39.9 27-39.9 54.9V416h-66.4V202.2h63.7v29.2h.9c8.9-16.8 30.6-34.5 62.9-34.5 67.2 0 79.7 44.3 79.7 101.9V416z"
+              fill="currentColor"
+            />
+          </svg>
+          <p
+            class="ContactEntryText"
+          >
+            <a
+              href="https://www.linkedin.com/in/jean-frederic-mainville-8566b485/"
+            >
+              LinkedIn
+            </a>
+          </p>
+        </div>
+        <div
+          class="ContactEntry"
+        >
+          <svg
+            aria-hidden="true"
+            class="svg-inline--fa fa-github "
+            data-icon="github"
+            data-prefix="fab"
+            focusable="false"
+            height="20"
+            role="img"
+            viewBox="0 0 496 512"
+            width="20"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3.3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5.3-6.2 2.3zm44.2-1.7c-2.9.7-4.9 2.6-4.6 4.9.3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.3-14.3-112.3-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3.7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3.3 2.9 2.3 3.9 1.6 1 3.6.7 4.3-.7.7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3.7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3.7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z"
+              fill="currentColor"
+            />
+          </svg>
+          <p
+            class="ContactEntryText"
+          >
+            <a
+              href="https://github.com/jfmainville"
+            >
+              GitHub
+            </a>
+          </p>
+        </div>
+      </div>
+      <div
+        class="Skills"
+      >
+        <h2>
+          Skills
+        </h2>
+        <ul
+          class="SkillsList"
+        >
+          <li>
+            Information Security
+          </li>
+          <li>
+            Cloud Infrastructure
+          </li>
+          <li>
+            DevOps
+          </li>
+          <li>
+            Software Development Security
+          </li>
+          <li>
+            Software Development
+          </li>
+        </ul>
+      </div>
+      <div
+        class="Education"
+      >
+        <h2>
+          Education
+        </h2>
+        <ul
+          class="EducationList"
+        >
+          <li>
+            Polytechnique Montreal / Bachelor of Science (B Sc.)
+          </li>
+          <li>
+            Polytechnique Montreal / Certificate in Cyberinvestigation
+          </li>
+          <li>
+            Polytechnique Montreal / Certificate in Cybersecurity
+          </li>
+          <li>
+            HEC Montreal / Certificate in E-Commerce
+          </li>
+          <li>
+            UQAM / Certificate in General Accounting
+          </li>
+        </ul>
+      </div>
+      <div
+        class="Certifications"
+      >
+        <h2>
+          Certifications
+        </h2>
+        <ul
+          class="CertificationsList"
+        >
+          <li>
+            Certified Information Systems Security Professional (CISSP)
+          </li>
+          <li>
+            GCP Professional Cloud Architect Certification
+          </li>
+          <li>
+            AWS Certified Solutions Architect – Associate
+          </li>
+        </ul>
+      </div>
+    </div>
+    <div
+      class="Page"
+    >
+      <div
+        class="Navigation"
+      >
+        <a
+          href="/"
+        >
+          Back to the home page
+        </a>
+        <div>
+          Export to PDF
+        </div>
+      </div>
+      <div
+        class="Resume"
+      >
+        <div
+          class="Header"
+        >
+          <h1>
+            Jean-Frederic Mainville
+          </h1>
+          <h2>
+            Cloud Security Specialist
+          </h2>
+        </div>
+        <div
+          class="Profile"
+        >
+          <h2>
+            Profile
+          </h2>
+          <p>
+            I am an experienced professional with expertise in cloud security, DevOps, and system administration. My career spans roles as a Cloud Security Specialist, Technical Product Owner, DevOps Specialist, Security Analyst, and System Administrator across diverse environments. I excel in designing and implementing secure IT solutions, automating processes, and optimizing performance to strengthen operational resilience and meet business objectives.
+          </p>
+        </div>
+        <div
+          class="WorkExperience"
+        >
+          <h2>
+            Work Experience
+          </h2>
+          <div
+            class="WorkExperienceEntry"
+          >
+            <h3
+              class="WorkExperienceEntryRole"
+            >
+              Cloud Security Specialist
+            </h3>
+            <p
+              style="margin-bottom: 1rem;"
+            >
+              PixMob / Montreal, Quebec, Canada / July 2022 - Now
+            </p>
+            <p>
+              As the lead Cloud Security Specialist within the Software team, I designed and implemented the cloud infrastructure hosted on the Google Cloud Platform (GCP) and established robust security guidelines and infrastructure:
+            </p>
+            <ul
+              class="WorkExperienceEntryList"
+            >
+              <li>
+                Created and executed a strategic security roadmap to improve the security posture and address existing gaps, ensuring alignment with business objectives and regulatory requirements
+              </li>
+              <li>
+                Designed and deployed GitLab CI pipelines to automate the deployment of services within our cloud infrastructure, improving the software development life cycle
+              </li>
+              <li>
+                Implemented security best practices and fortified our cloud infrastructure, as well as other solutions in our portfolio, to mitigate potential risks and vulnerabilities
+              </li>
+              <li>
+                Deployed and integrated advanced security application testing mechanisms, including secret detection and Static Application Security Testing (SAST), to proactively identify and address security vulnerabilities
+              </li>
+              <li>
+                Conducted regular security assessments, vulnerability scans, and penetration testing to identify and remediate security weaknesses, ensuring continuous compliance with industry standards and best practices
+              </li>
+              <li>
+                Established monitoring and incident response protocols to detect, respond to, and recover from security incidents, minimizing potential impacts
+              </li>
+            </ul>
+            <p
+              style="margin-top: 1rem; margin-bottom: 1rem;"
+            >
+              Environments
+            </p>
+            <p>
+              Google Cloud Platform (GCP), Google Kubernetes Engine (GKE), Datadog, Security Command Center, Cloud Run, Cloud SQL, MongoDB Atlas, PostgreSQL, Terraform, Ansible, GitLab, GitLab CI, Amazon Web Services (AWS), Javascript, Typescript, Next.js, React, Express.js, Python, Docker, Jira
+            </p>
+          </div>
+          <div
+            class="WorkExperienceEntry"
+          >
+            <h3
+              class="WorkExperienceEntryRole"
+            >
+              Technical Product Owner
+            </h3>
+            <p
+              style="margin-bottom: 1rem;"
+            >
+              Intact / Sainte-Hyacinthe, Quebec, Canada / August 2021 - June 2022
+            </p>
+            <p>
+              As a Technical Product Owner in the security operations team, I lead my team in implementing and maintaining solutions to enhance Intact's security posture:
+               
+            </p>
+            <ul
+              class="WorkExperienceEntryList"
+            >
+              <li>
+                Created and executed a strategic security roadmap to improve the security posture and address existing gaps, ensuring alignment with business objectives and regulatory requirements
+              </li>
+              <li>
+                Worked with internal and external auditors to design and implement necessary security controls, ensuring compliance with industry standards and best practices
+              </li>
+              <li>
+                Collaborated with the architecture team to design and optimize the existing SIEM infrastructure, enhancing detection and response capabilities
+              </li>
+              <li>
+                Partnered closely with the security incident response team (SIRT) to ensure our SIEM solution met operational needs and improve threat detection and response efficiency
+              </li>
+              <li>
+                Planned and prioritized sprint activities, setting clear goals to maximize value delivery and improve overall project outcomes - Regularly communicated with stakeholders, providing updates on SIEM solution progress, gathering feedback, and making data-driven decisions to enhance system performance
+              </li>
+              <li>
+                Implemented a continuous improvement process for the SIEM solution, incorporating feedback and new technologies to stay ahead of emerging threats like threat intelligence and threat hunting
+              </li>
+            </ul>
+            <p
+              style="margin-top: 1rem; margin-bottom: 1rem;"
+            >
+              Environments
+            </p>
+            <p>
+              Microsoft Azure, Microsoft Sentinel, Log Analytics Workspace (LAW), Elastic Stack, Microsoft 365 Defender, Ansible, Ubuntu, Logic Apps, Function Apps, Azure AD, GitHub Enterprise, Grafana, MITRE ATT&CK, Jira, Confluence
+            </p>
+          </div>
+          <div
+            class="WorkExperienceEntry"
+          >
+            <h3
+              class="WorkExperienceEntryRole"
+            >
+              DevOps Specialist
+            </h3>
+            <p
+              style="margin-bottom: 1rem;"
+            >
+              Intact / Sainte-Hyacinthe, Quebec, Canada / April 2019 - August 2021
+            </p>
+            <p>
+              As a DevOps Specialist in the identity and access management (IAM) team, I contributed to enhancing the efficiency and security of the IAM infrastructure:
+               
+            </p>
+            <ul
+              class="WorkExperienceEntryList"
+            >
+              <li>
+                Developed and refined Ansible playbooks for automating the deployment and configuration of IBM Security Access Manager, IBM Security Directory Suite, and Citrix ADC appliances, ensuring secure and consistent environments
+              </li>
+              <li>
+                Implemented configurations, patches, and vulnerability mitigation strategies across various platforms using Ansible, reducing vulnerabilities and ensuring compliance with security policies
+              </li>
+              <li>
+                Managed and configured Identity and Access Management (IAM) platforms, streamlining access control and improving security measures
+              </li>
+              <li>
+                Set up monitoring and alerting systems to detect and respond to operational and security incidents promptly, minimizing potential impact
+              </li>
+              <li>
+                Developed Python scripts for automating security tasks and processes, enhancing operational efficiency
+              </li>
+            </ul>
+            <p
+              style="margin-top: 1rem; margin-bottom: 1rem;"
+            >
+              Environments
+            </p>
+            <p>
+              Ansible, IBM Security Access Manager, IBM Security Directory Suite, Citrix ADC, RHEL, Python, Docker, Terraform, GitHub Enterprise, GitLab, Jira
+            </p>
+          </div>
+          <div
+            class="WorkExperienceEntry"
+          >
+            <h3
+              class="WorkExperienceEntryRole"
+            >
+              Full-Stack Developer
+            </h3>
+            <p
+              style="margin-bottom: 1rem;"
+            >
+              SCFJ / Montreal, Quebec, Canada / January 2018 - April 2019
+            </p>
+            <p>
+              As a Full-Stack Developer, I developed an internal web application to streamline the time-tracking process for freelancers at SCFJ:
+            </p>
+            <ul
+              class="WorkExperienceEntryList"
+            >
+              <li>
+                Designed the user experience and user interface of the web application using Figma, ensuring a user-friendly and visually appealing product
+              </li>
+              <li>
+                Built the web application from the ground up using React, Redux, and Django REST framework, delivering a robust and responsive solution
+              </li>
+              <li>
+                Developed a REST API with Django REST framework to facilitate seamless communication between the front-end and back-end
+              </li>
+              <li>
+                Implemented unit tests, integration tests and end-to-end (E2E) tests using Jest, Enzyme and Selenium to ensure code quality and reliability
+              </li>
+              <li>
+                Monitored project progress and deliverables, ensuring timely completion and organization
+              </li>
+              <li>
+                Applied IaC principles to deploy and configure the Google Kubernetes Engine (GKE) platform using Terraform, enhancing deployment efficiency
+              </li>
+              <li>
+                Deployed GitLab CI pipelines to automate the deployment process, ensuring continuous integration and delivery
+              </li>
+              <li>
+                Incorporated basic security practices in the application development lifecycle to ensure secure code and deployment
+              </li>
+            </ul>
+            <p
+              style="margin-top: 1rem; margin-bottom: 1rem;"
+            >
+              Environments
+            </p>
+            <p>
+              JavaScript, HTML, SCSS, React, Node.js, Django REST framework, Python, Redis, Jest, Enzyme, Selenium, Docker, Google Cloud Platform (GCP), Google Kubernetes Engine (GKE), Terraform, Ubuntu Server, Figma, Trello
+            </p>
+          </div>
+          <div
+            class="WorkExperienceEntry"
+          >
+            <h3
+              class="WorkExperienceEntryRole"
+            >
+              Security Analyst
+            </h3>
+            <p
+              style="margin-bottom: 1rem;"
+            >
+              CGI / Montreal, Quebec, Canada / June 2017 - December 2017
+            </p>
+            <p>
+              As a Security Analyst within the GTO business unit, I specialized in email security and monitoring to mitigate security risks:
+            </p>
+            <ul
+              class="WorkExperienceEntryList"
+            >
+              <li>
+                Analyzed email logs to proactively identify, prevent, and block potential threats such as SPAM, phishing attacks and other attack vectors
+              </li>
+              <li>
+                Managed and administered the Proofpoint-on-Demand (POD) platform to enhance email security and threat detection capabilities
+              </li>
+              <li>
+                Supported and maintained the Symantec Email Protection (SEP) platform, ensuring reliable email filtering and protection against emerging threats
+              </li>
+              <li>
+                Administered the Sophos SafeGuard encryption platform for CGI workstations, safeguarding sensitive data and ensuring compliance with security policies
+              </li>
+              <li>
+                Collaborated within ITIL incident and change management processes, ensuring efficient handling of security incidents and changes while adhering to best practices
+              </li>
+              <li>
+                Implemented and maintained operational procedures to enhance email security posture and response capabilities
+              </li>
+            </ul>
+            <p
+              style="margin-top: 1rem; margin-bottom: 1rem;"
+            >
+              Environments
+            </p>
+            <p>
+              IT Service Management (ITSM), ServiceNOW, Proofpoint-on-Demand (POD), Symantec Email Protection (SEP), Sophos SafeGuard
+            </p>
+          </div>
+          <div
+            class="WorkExperienceEntry"
+          >
+            <h3
+              class="WorkExperienceEntryRole"
+            >
+              System Administrator
+            </h3>
+            <p
+              style="margin-bottom: 1rem;"
+            >
+              CGI / Montreal, Quebec, Canada / November 2013 - October 2017
+            </p>
+            <p>
+              As a System Administrator within the Microsoft Center of Expertise (MCoE) business unit, I specialized in managing Windows Server, SharePoint, SQL Server, and Microsoft Azure environments to ensure optimal performance and security:
+               
+            </p>
+            <ul
+              class="WorkExperienceEntryList"
+            >
+              <li>
+                Developed and maintained PowerShell scripts to automate deployment, configuration, and monitoring for SharePoint environments, improving operational efficiency
+              </li>
+              <li>
+                Designed, deployed, and managed multiple Active Directory, ADFS, Web Application Proxy (WAP), and Dynamics CRM environments on Microsoft Azure, ensuring scalable and secure infrastructures
+              </li>
+              <li>
+                Installed and configured highly available clustered environments for SharePoint Server (2007, 2010, 2013) and Project Server (2010, 2013), optimizing performance and reliability
+              </li>
+              <li>
+                Conducted comprehensive workload tests to identify and address performance bottlenecks, enhancing overall SharePoint environment performance
+              </li>
+              <li>
+                Led and executed migrations of SharePoint environments to newer versions, ensuring minimal downtime and seamless transition - Implemented security best practices and configurations across SharePoint, SQL Server, and Azure environments to safeguard data and comply with organizational policies
+              </li>
+              <li>
+                Collaborated with cross-functional teams to troubleshoot complex technical issues and provide timely resolutions
+              </li>
+            </ul>
+            <p
+              style="margin-top: 1rem; margin-bottom: 1rem;"
+            >
+              Environments
+            </p>
+            <p>
+              PowerShell, Windows Server (2008 R2, 2012 R2), Active Directory, DNS Server, Group Policies, Microsoft Azure, Dynamics CRM (2011, 2013, 2015, 2016), ADFS, Web Application Proxy (WAP), SQL Server (2008 R2, 2012, 2014), SSRS, SharePoint Server (2010, 2013, 2016), Project Server (2010, 2013, 2016)
+            </p>
+          </div>
+        </div>
+        <div />
+      </div>
+    </div>
+  </section>
+</div>
+`;

--- a/src/app/resume/page.module.scss
+++ b/src/app/resume/page.module.scss
@@ -1,0 +1,57 @@
+@import "../variables.module.scss";
+
+.Main {
+  display: grid;
+  grid-template-columns: 1fr 4fr;
+  justify-content: center;
+  background-color: #eeeeee;
+  color: $background-color;
+  height: 100vh;
+  width: 100vw;
+}
+
+.Sidebar {
+  background-color: $secondary-color;
+  color: $text-color;
+}
+
+.Navigation {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  margin: 2rem;
+}
+
+.Resume {
+  margin: 2rem;
+}
+
+.Header {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.Profile {
+  margin-top: 2rem;
+  text-align: justify;
+}
+
+.WorkExperience {
+  margin-top: 2rem;
+}
+
+.WorkExperienceEntry {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 1rem;
+}
+
+.WorkExperienceEntryRole {
+  color: $secondary-color;
+}
+
+.WorkExperienceEntryList {
+  margin: 1rem 0 0 2rem;
+}

--- a/src/app/resume/page.module.scss
+++ b/src/app/resume/page.module.scss
@@ -18,6 +18,11 @@
 
 .PdfExportButton {
   cursor: pointer;
+  outline: none;
+  border: none;
+  font-size: 16px;
+  background-color: transparent;
+  color: $background-color;
 }
 
 .Sidebar {

--- a/src/app/resume/page.module.scss
+++ b/src/app/resume/page.module.scss
@@ -13,6 +13,53 @@
 .Sidebar {
   background-color: $secondary-color;
   color: $text-color;
+  padding: 1rem 1rem 1rem 1rem;
+}
+
+.Contact {
+  display: flex;
+  flex-direction: column;
+}
+
+.ContactEntry {
+  display: flex;
+  flex-direction: row;
+  margin: 0 0 1rem 0;
+}
+
+.ContactEntryText {
+  margin-left: 1rem;
+}
+
+.Skills {
+  display: flex;
+  flex-direction: column;
+}
+
+.SkillsList {
+  margin: 0 0 0 1rem;
+}
+
+.Education {
+  display: flex;
+  flex-direction: column;
+}
+
+.EducationList {
+  margin: 0 0 0 1rem;
+}
+
+.Certifications {
+  display: flex;
+  flex-direction: column;
+}
+
+.CertificationsList {
+  margin: 0 0 0 1rem;
+}
+
+.Page {
+  background-color: #eeeeee;
 }
 
 .Navigation {

--- a/src/app/resume/page.module.scss
+++ b/src/app/resume/page.module.scss
@@ -1,13 +1,23 @@
 @import "../variables.module.scss";
 
+@media print {
+  .Navigation {
+    display: none !important;
+  }
+}
+
 .Main {
   display: grid;
   grid-template-columns: 1fr 4fr;
   justify-content: center;
   background-color: #eeeeee;
   color: $background-color;
-  height: 100vh;
+  min-height: 100vh;
   width: 100vw;
+}
+
+.PdfExportButton {
+  cursor: pointer;
 }
 
 .Sidebar {

--- a/src/app/resume/page.test.tsx
+++ b/src/app/resume/page.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import Resume from "./page";
+
+describe("<Resume/> Test Suite", () => {
+  it("should render the <Resume/> page unchanged", () => {
+    const { container } = render(<Resume />);
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/src/app/resume/page.tsx
+++ b/src/app/resume/page.tsx
@@ -91,8 +91,8 @@ const ResumePage = () => {
       <div className={styles.Page}>
         <div id="Navigation" className={styles.Navigation}>
           <Link href={"/"}>Back to the home page</Link>
-          <div className={styles.PdfExportButton} onClick={handlePdfExport}>
-            Export to PDF
+          <div onClick={handlePdfExport}>
+            <button className={styles.PdfExportButton}>Export to PDF</button>
           </div>
         </div>
         <div className={styles.Resume}>

--- a/src/app/resume/page.tsx
+++ b/src/app/resume/page.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import styles from "./page.module.scss";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faEnvelope } from "@fortawesome/free-regular-svg-icons";
@@ -7,6 +9,12 @@ import { faGithub } from "@fortawesome/free-brands-svg-icons/faGithub";
 import { faGlobe } from "@fortawesome/free-solid-svg-icons";
 
 const ResumePage = () => {
+  const handlePdfExport = async () => {
+    await fetch("/api/resume", {
+      method: "POST",
+    });
+  };
+
   return (
     <section className={styles.Main}>
       <div className={styles.Sidebar}>
@@ -69,9 +77,11 @@ const ResumePage = () => {
         </div>
       </div>
       <div className={styles.Page}>
-        <div className={styles.Navigation}>
+        <div id="Navigation" className={styles.Navigation}>
           <Link href={"/"}>Back to the home page</Link>
-          <div>Export to PDF</div>
+          <div className={styles.PdfExportButton} onClick={handlePdfExport}>
+            Export to PDF
+          </div>
         </div>
         <div className={styles.Resume}>
           <div className={styles.Header}>

--- a/src/app/resume/page.tsx
+++ b/src/app/resume/page.tsx
@@ -1,5 +1,389 @@
+import styles from "./page.module.scss";
+
 const ResumePage = () => {
-  return <div>Hello Resume Page</div>;
+  return (
+    <section className={styles.Main}>
+      <div className={styles.Sidebar}>
+        <div className={styles.Contact}>
+          <h2>Contact</h2>
+        </div>
+        <div className={styles.Skills}>
+          <h2>Skills</h2>
+        </div>
+        <div className={styles.Education}>
+          <h2>Education</h2>
+        </div>
+        <div className={styles.Certifications}>
+          <h2>Certifications</h2>
+        </div>
+      </div>
+      <div>
+        <div className={styles.Navigation}>
+          <div>Back to the home page</div>
+          <div>Export to PDF</div>
+        </div>
+        <div className={styles.Resume}>
+          <div className={styles.Header}>
+            <h1>Jean-Frederic Mainville</h1>
+            <h2>Cloud Security Specialist</h2>
+          </div>
+          <div className={styles.Profile}>
+            <h2>Profile</h2>
+            <p>
+              I am an experienced professional with expertise in cloud security,
+              DevOps, and system administration. My career spans roles as a
+              Cloud Security Specialist, Technical Product Owner, DevOps
+              Specialist, Security Analyst, and System Administrator across
+              diverse environments. I excel in designing and implementing secure
+              IT solutions, automating processes, and optimizing performance to
+              strengthen operational resilience and meet business objectives.
+            </p>
+          </div>
+          <div className={styles.WorkExperience}>
+            <h2>Work Experience</h2>
+            <div className={styles.WorkExperienceEntry}>
+              <h3 className={styles.WorkExperienceEntryRole}>
+                Cloud Security Specialist
+              </h3>
+              <p style={{ marginBottom: "1rem" }}>
+                PixMob / Montreal, Quebec, Canada / July 2022 - Now
+              </p>
+              <p>
+                As the lead Cloud Security Specialist within the Software team,
+                I designed and implemented the cloud infrastructure hosted on
+                the Google Cloud Platform (GCP) and established robust security
+                guidelines and infrastructure:
+              </p>
+              <ul className={styles.WorkExperienceEntryList}>
+                <li>
+                  Created and executed a strategic security roadmap to improve
+                  the security posture and address existing gaps, ensuring
+                  alignment with business objectives and regulatory requirements
+                </li>
+                <li>
+                  Designed and deployed GitLab CI pipelines to automate the
+                  deployment of services within our cloud infrastructure,
+                  improving the software development life cycle
+                </li>
+                <li>
+                  Implemented security best practices and fortified our cloud
+                  infrastructure, as well as other solutions in our portfolio,
+                  to mitigate potential risks and vulnerabilities
+                </li>
+                <li>
+                  Deployed and integrated advanced security application testing
+                  mechanisms, including secret detection and Static Application
+                  Security Testing (SAST), to proactively identify and address
+                  security vulnerabilities
+                </li>
+                <li>
+                  Conducted regular security assessments, vulnerability scans,
+                  and penetration testing to identify and remediate security
+                  weaknesses, ensuring continuous compliance with industry
+                  standards and best practices
+                </li>
+                <li>
+                  Established monitoring and incident response protocols to
+                  detect, respond to, and recover from security incidents,
+                  minimizing potential impacts
+                </li>
+              </ul>
+              <p style={{ marginTop: "1rem", marginBottom: "1rem" }}>
+                Environments
+              </p>
+              <p>
+                Google Cloud Platform (GCP), Google Kubernetes Engine (GKE),
+                Datadog, Security Command Center, Cloud Run, Cloud SQL, MongoDB
+                Atlas, PostgreSQL, Terraform, Ansible, GitLab, GitLab CI, Amazon
+                Web Services (AWS), Javascript, Typescript, Next.js, React,
+                Express.js, Python, Docker, Jira
+              </p>
+            </div>
+            <div className={styles.WorkExperienceEntry}>
+              <h3 className={styles.WorkExperienceEntryRole}>
+                Technical Product Owner
+              </h3>
+              <p style={{ marginBottom: "1rem" }}>
+                Intact / Sainte-Hyacinthe, Quebec, Canada / August 2021 - June
+                2022
+              </p>
+              <p>
+                As a Technical Product Owner in the security operations team, I
+                lead my team in implementing and maintaining solutions to
+                enhance Intact's security posture:{" "}
+              </p>
+              <ul className={styles.WorkExperienceEntryList}>
+                <li>
+                  Created and executed a strategic security roadmap to improve
+                  the security posture and address existing gaps, ensuring
+                  alignment with business objectives and regulatory requirements
+                </li>
+                <li>
+                  Worked with internal and external auditors to design and
+                  implement necessary security controls, ensuring compliance
+                  with industry standards and best practices
+                </li>
+                <li>
+                  Collaborated with the architecture team to design and optimize
+                  the existing SIEM infrastructure, enhancing detection and
+                  response capabilities
+                </li>
+                <li>
+                  Partnered closely with the security incident response team
+                  (SIRT) to ensure our SIEM solution met operational needs and
+                  improve threat detection and response efficiency
+                </li>
+                <li>
+                  Planned and prioritized sprint activities, setting clear goals
+                  to maximize value delivery and improve overall project
+                  outcomes - Regularly communicated with stakeholders, providing
+                  updates on SIEM solution progress, gathering feedback, and
+                  making data-driven decisions to enhance system performance
+                </li>
+                <li>
+                  Implemented a continuous improvement process for the SIEM
+                  solution, incorporating feedback and new technologies to stay
+                  ahead of emerging threats like threat intelligence and threat
+                  hunting
+                </li>
+              </ul>
+              <p style={{ marginTop: "1rem", marginBottom: "1rem" }}>
+                Environments
+              </p>
+              <p>
+                Microsoft Azure, Microsoft Sentinel, Log Analytics Workspace
+                (LAW), Elastic Stack, Microsoft 365 Defender, Ansible, Ubuntu,
+                Logic Apps, Function Apps, Azure AD, GitHub Enterprise, Grafana,
+                MITRE ATT&CK, Jira, Confluence
+              </p>
+            </div>
+            <div className={styles.WorkExperienceEntry}>
+              <h3 className={styles.WorkExperienceEntryRole}>
+                DevOps Specialist
+              </h3>
+              <p style={{ marginBottom: "1rem" }}>
+                Intact / Sainte-Hyacinthe, Quebec, Canada / April 2019 - August
+                2021
+              </p>
+              <p>
+                As a DevOps Specialist in the identity and access management
+                (IAM) team, I contributed to enhancing the efficiency and
+                security of the IAM infrastructure:{" "}
+              </p>
+              <ul className={styles.WorkExperienceEntryList}>
+                <li>
+                  Developed and refined Ansible playbooks for automating the
+                  deployment and configuration of IBM Security Access Manager,
+                  IBM Security Directory Suite, and Citrix ADC appliances,
+                  ensuring secure and consistent environments
+                </li>
+                <li>
+                  Implemented configurations, patches, and vulnerability
+                  mitigation strategies across various platforms using Ansible,
+                  reducing vulnerabilities and ensuring compliance with security
+                  policies
+                </li>
+                <li>
+                  Managed and configured Identity and Access Management (IAM)
+                  platforms, streamlining access control and improving security
+                  measures
+                </li>
+                <li>
+                  Set up monitoring and alerting systems to detect and respond
+                  to operational and security incidents promptly, minimizing
+                  potential impact
+                </li>
+                <li>
+                  Developed Python scripts for automating security tasks and
+                  processes, enhancing operational efficiency
+                </li>
+              </ul>
+              <p style={{ marginTop: "1rem", marginBottom: "1rem" }}>
+                Environments
+              </p>
+              <p>
+                Ansible, IBM Security Access Manager, IBM Security Directory
+                Suite, Citrix ADC, RHEL, Python, Docker, Terraform, GitHub
+                Enterprise, GitLab, Jira
+              </p>
+            </div>
+            <div className={styles.WorkExperienceEntry}>
+              <h3 className={styles.WorkExperienceEntryRole}>
+                Full-Stack Developer
+              </h3>
+              <p style={{ marginBottom: "1rem" }}>
+                SCFJ / Montreal, Quebec, Canada / January 2018 - April 2019
+              </p>
+              <p>
+                As a Full-Stack Developer, I developed an internal web
+                application to streamline the time-tracking process for
+                freelancers at SCFJ:
+              </p>
+              <ul className={styles.WorkExperienceEntryList}>
+                <li>
+                  Designed the user experience and user interface of the web
+                  application using Figma, ensuring a user-friendly and visually
+                  appealing product
+                </li>
+                <li>
+                  Built the web application from the ground up using React,
+                  Redux, and Django REST framework, delivering a robust and
+                  responsive solution
+                </li>
+                <li>
+                  Developed a REST API with Django REST framework to facilitate
+                  seamless communication between the front-end and back-end
+                </li>
+                <li>
+                  Implemented unit tests, integration tests and end-to-end (E2E)
+                  tests using Jest, Enzyme and Selenium to ensure code quality
+                  and reliability
+                </li>
+                <li>
+                  Monitored project progress and deliverables, ensuring timely
+                  completion and organization
+                </li>
+                <li>
+                  Applied IaC principles to deploy and configure the Google
+                  Kubernetes Engine (GKE) platform using Terraform, enhancing
+                  deployment efficiency
+                </li>
+                <li>
+                  Deployed GitLab CI pipelines to automate the deployment
+                  process, ensuring continuous integration and delivery
+                </li>
+                <li>
+                  Incorporated basic security practices in the application
+                  development lifecycle to ensure secure code and deployment
+                </li>
+              </ul>
+              <p style={{ marginTop: "1rem", marginBottom: "1rem" }}>
+                Environments
+              </p>
+              <p>
+                JavaScript, HTML, SCSS, React, Node.js, Django REST framework,
+                Python, Redis, Jest, Enzyme, Selenium, Docker, Google Cloud
+                Platform (GCP), Google Kubernetes Engine (GKE), Terraform,
+                Ubuntu Server, Figma, Trello
+              </p>
+            </div>
+            <div className={styles.WorkExperienceEntry}>
+              <h3 className={styles.WorkExperienceEntryRole}>
+                Security Analyst
+              </h3>
+              <p style={{ marginBottom: "1rem" }}>
+                CGI / Montreal, Quebec, Canada / June 2017 - December 2017
+              </p>
+              <p>
+                As a Security Analyst within the GTO business unit, I
+                specialized in email security and monitoring to mitigate
+                security risks:
+              </p>
+              <ul className={styles.WorkExperienceEntryList}>
+                <li>
+                  Analyzed email logs to proactively identify, prevent, and
+                  block potential threats such as SPAM, phishing attacks and
+                  other attack vectors
+                </li>
+                <li>
+                  Managed and administered the Proofpoint-on-Demand (POD)
+                  platform to enhance email security and threat detection
+                  capabilities
+                </li>
+                <li>
+                  Supported and maintained the Symantec Email Protection (SEP)
+                  platform, ensuring reliable email filtering and protection
+                  against emerging threats
+                </li>
+                <li>
+                  Administered the Sophos SafeGuard encryption platform for CGI
+                  workstations, safeguarding sensitive data and ensuring
+                  compliance with security policies
+                </li>
+                <li>
+                  Collaborated within ITIL incident and change management
+                  processes, ensuring efficient handling of security incidents
+                  and changes while adhering to best practices
+                </li>
+                <li>
+                  Implemented and maintained operational procedures to enhance
+                  email security posture and response capabilities
+                </li>
+              </ul>
+              <p style={{ marginTop: "1rem", marginBottom: "1rem" }}>
+                Environments
+              </p>
+              <p>
+                IT Service Management (ITSM), ServiceNOW, Proofpoint-on-Demand
+                (POD), Symantec Email Protection (SEP), Sophos SafeGuard
+              </p>
+            </div>
+            <div className={styles.WorkExperienceEntry}>
+              <h3 className={styles.WorkExperienceEntryRole}>
+                System Administrator
+              </h3>
+              <p style={{ marginBottom: "1rem" }}>
+                CGI / Montreal, Quebec, Canada / November 2013 - October 2017
+              </p>
+              <p>
+                As a System Administrator within the Microsoft Center of
+                Expertise (MCoE) business unit, I specialized in managing
+                Windows Server, SharePoint, SQL Server, and Microsoft Azure
+                environments to ensure optimal performance and security:{" "}
+              </p>
+              <ul className={styles.WorkExperienceEntryList}>
+                <li>
+                  Developed and maintained PowerShell scripts to automate
+                  deployment, configuration, and monitoring for SharePoint
+                  environments, improving operational efficiency
+                </li>
+                <li>
+                  Designed, deployed, and managed multiple Active Directory,
+                  ADFS, Web Application Proxy (WAP), and Dynamics CRM
+                  environments on Microsoft Azure, ensuring scalable and secure
+                  infrastructures
+                </li>
+                <li>
+                  Installed and configured highly available clustered
+                  environments for SharePoint Server (2007, 2010, 2013) and
+                  Project Server (2010, 2013), optimizing performance and
+                  reliability
+                </li>
+                <li>
+                  Conducted comprehensive workload tests to identify and address
+                  performance bottlenecks, enhancing overall SharePoint
+                  environment performance
+                </li>
+                <li>
+                  Led and executed migrations of SharePoint environments to
+                  newer versions, ensuring minimal downtime and seamless
+                  transition - Implemented security best practices and
+                  configurations across SharePoint, SQL Server, and Azure
+                  environments to safeguard data and comply with organizational
+                  policies
+                </li>
+                <li>
+                  Collaborated with cross-functional teams to troubleshoot
+                  complex technical issues and provide timely resolutions
+                </li>
+              </ul>
+              <p style={{ marginTop: "1rem", marginBottom: "1rem" }}>
+                Environments
+              </p>
+              <p>
+                PowerShell, Windows Server (2008 R2, 2012 R2), Active Directory,
+                DNS Server, Group Policies, Microsoft Azure, Dynamics CRM (2011,
+                2013, 2015, 2016), ADFS, Web Application Proxy (WAP), SQL Server
+                (2008 R2, 2012, 2014), SSRS, SharePoint Server (2010, 2013,
+                2016), Project Server (2010, 2013, 2016)
+              </p>
+            </div>
+          </div>
+          <div></div>
+        </div>
+      </div>
+    </section>
+  );
 };
 
 export default ResumePage;

--- a/src/app/resume/page.tsx
+++ b/src/app/resume/page.tsx
@@ -1,4 +1,10 @@
 import styles from "./page.module.scss";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faEnvelope } from "@fortawesome/free-regular-svg-icons";
+import { faLinkedin } from "@fortawesome/free-brands-svg-icons";
+import Link from "next/link";
+import { faGithub } from "@fortawesome/free-brands-svg-icons/faGithub";
+import { faGlobe } from "@fortawesome/free-solid-svg-icons";
 
 const ResumePage = () => {
   return (
@@ -6,20 +12,65 @@ const ResumePage = () => {
       <div className={styles.Sidebar}>
         <div className={styles.Contact}>
           <h2>Contact</h2>
+          <div className={styles.ContactEntry}>
+            <FontAwesomeIcon icon={faGlobe} width="20" height="20" />
+            <p className={styles.ContactEntryText}>
+              <Link href="https://jfmainville.me">My Site</Link>
+            </p>
+          </div>
+          <div className={styles.ContactEntry}>
+            <FontAwesomeIcon icon={faEnvelope} width="20" height="20" />
+            <p className={styles.ContactEntryText}>
+              <Link href="mailto:jfmainville@outlook.com">Email</Link>
+            </p>
+          </div>
+          <div className={styles.ContactEntry}>
+            <FontAwesomeIcon icon={faLinkedin} width="20" height="20" />
+            <p className={styles.ContactEntryText}>
+              <Link href="https://www.linkedin.com/in/jean-frederic-mainville-8566b485/">
+                LinkedIn
+              </Link>
+            </p>
+          </div>
+          <div className={styles.ContactEntry}>
+            <FontAwesomeIcon icon={faGithub} width="20" height="20" />
+            <p className={styles.ContactEntryText}>
+              <Link href="https://github.com/jfmainville">GitHub</Link>
+            </p>
+          </div>
         </div>
         <div className={styles.Skills}>
           <h2>Skills</h2>
+          <ul className={styles.SkillsList}>
+            <li>Information Security</li>
+            <li>Cloud Infrastructure</li>
+            <li>DevOps</li>
+            <li>Software Development Security</li>
+            <li>Software Development</li>
+          </ul>
         </div>
         <div className={styles.Education}>
           <h2>Education</h2>
+          <ul className={styles.EducationList}>
+            <li>Polytechnique Montreal / Bachelor of Science (B Sc.)</li>
+            <li>Polytechnique Montreal / Certificate in Cyberinvestigation</li>
+            <li>Polytechnique Montreal / Certificate in Cybersecurity</li>
+            <li>HEC Montreal / Certificate in E-Commerce</li>
+            <li>UQAM / Certificate in General Accounting</li>
+          </ul>
         </div>
         <div className={styles.Certifications}>
           <h2>Certifications</h2>
+          <ul className={styles.CertificationsList}>
+            <li>Certified Information Systems Security Professional (CISSP)</li>
+            <li>GCP Professional Cloud Architect Certification</li>
+            <li>AWS Certified Solutions Architect – Associate</li>
+          </ul>
         </div>
       </div>
-      <div>
+      <div className={styles.Page}>
         <div className={styles.Navigation}>
-          <div>Back to the home page</div>
+          <Link href={"/"}>Back to the home page</Link>
           <div>Export to PDF</div>
         </div>
         <div className={styles.Resume}>

--- a/src/app/resume/page.tsx
+++ b/src/app/resume/page.tsx
@@ -10,9 +10,20 @@ import { faGlobe } from "@fortawesome/free-solid-svg-icons";
 
 const ResumePage = () => {
   const handlePdfExport = async () => {
-    await fetch("/api/resume", {
-      method: "POST",
+    const response = await fetch("/api/resume", {
+      method: "GET",
     });
+
+    if (response.ok) {
+      const blob = await response.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "Resume_Jean_Frederic_Mainville.pdf";
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+    }
   };
 
   return (

--- a/src/app/resume/page.tsx
+++ b/src/app/resume/page.tsx
@@ -7,6 +7,7 @@ import { faLinkedin } from "@fortawesome/free-brands-svg-icons";
 import Link from "next/link";
 import { faGithub } from "@fortawesome/free-brands-svg-icons/faGithub";
 import { faGlobe } from "@fortawesome/free-solid-svg-icons";
+import { RESUME_FILENAME } from "../utils/constants";
 
 const ResumePage = () => {
   const handlePdfExport = async () => {
@@ -19,7 +20,7 @@ const ResumePage = () => {
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;
-      a.download = "Resume_Jean_Frederic_Mainville.pdf";
+      a.download = RESUME_FILENAME;
       document.body.appendChild(a);
       a.click();
       a.remove();

--- a/src/app/utils/constants.ts
+++ b/src/app/utils/constants.ts
@@ -1,0 +1,7 @@
+export const currentDateTime: Date = new Date(
+  new Date().toISOString().slice(0, -5) + "Z",
+);
+
+export const PORT = process.env.PORT || "3000";
+export const HOSTNAME = process.env.HOSTNAME || `http://localhost:${PORT}`;
+export const RESUME_FILENAME = "Resume_Jean_Frederic_Mainville.pdf";


### PR DESCRIPTION
# Changes

- Add the `Resume` page base configuration
- Add all the required entries for my resume
- Update the `global.css` styling configuration for multiple attributes
- Install the playwright NPM packages in the project
- Add the export to PDF base configuration
- Create the `/api/resume` API endpoint to complete the export to PDF action to the relative path
- Fix the return `response` for all API endpoints as an `Object` configuration error was returned previously
- Update the `.gitignore` file to exclude the Playwright files and directories
- Add the `constants.ts` file to the project
- Add tests to validate the execution of the PDF export functionality

# Additional Notes

- There are a lot of improvements that can be made the `Resume` page, but it will do the job for now with the current styling
- The export to PDF functionality leverages the Playwright tool. This tool is primarily used for end-to-end testing, but it can also be used to export an HTML page to a PDF file. This feature is leveraged for permitting the export of the Resume page to a PDF file

# Related Changes

NUA-27 #Done