### PR TITLE
NUA-30: Add the CSS media queries

### DIFF
--- a/src/app/components/About/index.module.scss
+++ b/src/app/components/About/index.module.scss
@@ -25,6 +25,12 @@
   padding: 0 0 0 2rem;
 }
 
+@media (max-width: $small-screen) {
+  .AboutSectionText {
+    text-align: center;
+  }
+}
+
 .TextHeading {
   margin: 2rem;
 }

--- a/src/app/components/About/index.module.scss
+++ b/src/app/components/About/index.module.scss
@@ -12,6 +12,12 @@
   flex-direction: row;
 }
 
+@media (max-width: $small-screen) {
+  .AboutSection {
+    flex-direction: column;
+  }
+}
+
 .AboutSectionText {
   display: flex;
   text-align: end;

--- a/src/app/components/Contact/index.module.scss
+++ b/src/app/components/Contact/index.module.scss
@@ -53,6 +53,12 @@
   background-color: $secondary-color;
 }
 
+@media (max-width: $small-screen) {
+  .TextArea {
+    width: 100%;
+  }
+}
+
 .SubmitButton {
   display: flex;
   align-items: center;

--- a/src/app/components/Contact/index.module.scss
+++ b/src/app/components/Contact/index.module.scss
@@ -7,10 +7,16 @@
 }
 
 .ContactSection {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
+  display: flex;
+  flex-direction: row;
   align-items: center;
-  justify-content: center;
+  justify-content: space-around;
+}
+
+@media (max-width: $small-screen) {
+  .ContactSection {
+    flex-direction: column;
+  }
 }
 
 .ContactSectionHeader {

--- a/src/app/components/Experience/index.module.scss
+++ b/src/app/components/Experience/index.module.scss
@@ -36,12 +36,12 @@
 
 .ExperienceSectionEntryLine {
   width: 0.1rem;
-  height: 15rem;
+  height: 100%;
   background: $secondary-color;
 }
 .ExperienceSectionEntryLineRight {
   width: 0.1rem;
-  height: 15rem;
+  height: 100%;
   margin-left: 7px;
   background: $secondary-color;
 }

--- a/src/app/resume/page.module.scss
+++ b/src/app/resume/page.module.scss
@@ -16,6 +16,12 @@
   width: 100vw;
 }
 
+@media (max-width: $small-screen) {
+  .Main {
+    grid-template-columns: 1fr;
+  }
+}
+
 .PdfExportButton {
   cursor: pointer;
   outline: none;

--- a/src/app/variables.module.scss
+++ b/src/app/variables.module.scss
@@ -10,6 +10,7 @@ $text-color: #eeeeee;
 // Shadows
 
 // Media Queries
+$small-screen: 705px;
 
 :export {
   fontFamily: $font-family;
@@ -17,4 +18,5 @@ $text-color: #eeeeee;
   primaryColor: $primary-color;
   secondaryColor: $secondary-color;
   textColor: $text-color;
+  smallScreen: $small-screen;
 }


### PR DESCRIPTION
# Changes

- Add the `small-screen` SCSS variable with a value of `705px` which was the minimum width where the layout was no longer optimal
- Add media queries the `About` component styling to make sure that the text and image isn't being crammed together when the screen size is getting smaller
- Update the `Contact` component styling to give more room to the contact form
- Update the `Resume` page styling to change layout to a column to make the text easier to read in each section
- Update the `Experience` timeline line height to better adjust to screen size change

# Additional Notes

# Related Changes

NUA-30 #done