### PR TITLE
NUA-43: Add the Google Analytics base configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@fortawesome/free-regular-svg-icons": "^6.6.0",
         "@fortawesome/free-solid-svg-icons": "^6.6.0",
         "@fortawesome/react-fontawesome": "^0.2.2",
+        "@next/third-parties": "^14.2.14",
         "@playwright/test": "^1.47.1",
         "next": "14.2.7",
         "nodemailer": "^6.9.15",
@@ -1908,6 +1909,19 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@next/third-parties": {
+      "version": "14.2.14",
+      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-14.2.14.tgz",
+      "integrity": "sha512-Flyy7/HqQ5mqg/EkPh9gTh+Ea4Yv1rJM5pOCBYZoOA0eHdSROQO/qpNQ/gOPEMyg1EVDunH0nuAK82GC4BogRA==",
+      "license": "MIT",
+      "dependencies": {
+        "third-party-capital": "1.0.20"
+      },
+      "peerDependencies": {
+        "next": "^13.0.0 || ^14.0.0",
+        "react": "^18.2.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -8713,6 +8727,12 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "node_modules/third-party-capital": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
+      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==",
+      "license": "ISC"
     },
     "node_modules/tmpl": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@fortawesome/free-regular-svg-icons": "^6.6.0",
     "@fortawesome/free-solid-svg-icons": "^6.6.0",
     "@fortawesome/react-fontawesome": "^0.2.2",
+    "@next/third-parties": "^14.2.14",
     "@playwright/test": "^1.47.1",
     "next": "14.2.7",
     "nodemailer": "^6.9.15",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { GoogleAnalytics } from "@next/third-parties/google";
 import { Inter } from "next/font/google";
 import "./globals.css";
 
@@ -17,6 +18,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={inter.className}>{children}</body>
+      <GoogleAnalytics gaId="G-B14Q3RXS9N" />
     </html>
   );
 }


### PR DESCRIPTION
# Changes

- Add the `@next/third-parties` NPM package to the project
- Add the `GoogleAnalytics` component to the `layout.tsx` file to monitor all the routes

# Additional Notes

- The Google Analytics Measurement ID is hardcoded into the code directly instead of using an environment variable as it should never change
- The Measurement ID is public information and can be shown on the client side
- It won't be possible to validate that the Google Analytics data stream is working properly until this PR is merged
- Additional PRs might be required to validate that it works properly