### PR TITLE
NUA-72: Fix the contact form email delivery issue

### DIFF
--- a/.github/workflows/container-apps-deploy.yml
+++ b/.github/workflows/container-apps-deploy.yml
@@ -45,5 +45,5 @@ jobs:
           resourceGroup: ${{ vars.AZURE_RESOURCE_GROUP_NAME }}
           imageToDeploy: ${{ vars.AZURE_ACR_URL }}/my-site:${{ github.SHA }}
           environmentVariables: |
-            "OUTLOOK_SMTP_SERVER=${{ vars.OUTLOOK_SMTP_SERVER }}" "OUTLOOK_SMTP_SERVER_PORT=${{ vars.OUTLOOK_SMTP_SERVER_PORT }}" "OUTLOOK_EMAIL=${{ vars.OUTLOOK_EMAIL }}" "OUTLOOK_APP_PASSWORD=secretref:outlook-app-password"
+            "GMAIL_SMTP_SERVER=${{ vars.GMAIL_SMTP_SERVER }}" "GMAIL_SMTP_SERVER_PORT=${{ vars.GMAIL_SMTP_SERVER_PORT }}" "GMAIL_EMAIL=${{ vars.GMAIL_EMAIL }}" "GMAIL_APP_PASSWORD=secretref:gmail-app-password"
     needs: build

--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ The following applications need to be installed on the local computer in order t
 
 The following environment variables needs to be set to use this application:
 
-| Name                     | Description                                                             | Example               |
-| ------------------------ | :---------------------------------------------------------------------- | :-------------------- |
-| OUTLOOK_SMTP_SERVER      | Outlook SMTP server URL                                                 | smtp-mail.outlook.com |
-| OUTLOOK_SMTP_SERVER_PORT | Outlook SMTP server port                                                | 587                   |
-| OUTLOOK_EMAIL            | Destination email address                                               | test@outlook.com      |
-| OUTLOOK_APP_PASSWORD     | Outlook App password that can be generated from the Outlook web console |                       |
+| Name                   | Description                                                         | Example        |
+| ---------------------- | :------------------------------------------------------------------ | :------------- |
+| GMAIL_SMTP_SERVER      | Gmail SMTP server URL                                               | smtp.gmail.com |
+| GMAIL_SMTP_SERVER_PORT | Gmail SMTP server port                                              | 587            |
+| GMAIL_EMAIL            | Destination email address                                           | test@gmail.com |
+| GMAIL_APP_PASSWORD     | Gmail App password that can be generated from the Gmail web console |                |
 
 ### Development
 

--- a/src/app/__snapshots__/page.test.tsx.snap
+++ b/src/app/__snapshots__/page.test.tsx.snap
@@ -464,6 +464,7 @@ exports[`<Home/> Test Suite should render the <Home/> component unchanged 1`] = 
               name="firstName"
               required=""
               type="text"
+              value=""
             />
             <label
               class="InputLabel"
@@ -477,6 +478,7 @@ exports[`<Home/> Test Suite should render the <Home/> component unchanged 1`] = 
               name="lastName"
               required=""
               type="text"
+              value=""
             />
             <label
               class="InputLabel"
@@ -490,6 +492,7 @@ exports[`<Home/> Test Suite should render the <Home/> component unchanged 1`] = 
               name="email"
               required=""
               type="email"
+              value=""
             />
             <label
               class="InputLabel"
@@ -502,6 +505,7 @@ exports[`<Home/> Test Suite should render the <Home/> component unchanged 1`] = 
               id="phone"
               name="phone"
               type="text"
+              value=""
             />
             <label
               class="InputLabel"

--- a/src/app/api/email/route.ts
+++ b/src/app/api/email/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { transporter } from "../../lib/nodemailer/nodemailerConfig";
+import { GMAIL_EMAIL } from "../../utils/constants";
 
 export async function POST(request: Request) {
   const formData = await request.formData();
@@ -9,13 +10,13 @@ export async function POST(request: Request) {
   const phone = formData.get("phone");
   const message = formData.get("message");
 
-  const info = await transporter.sendMail({
-    from: process.env.OUTLOOK_EMAIL,
-    to: process.env.OUTLOOK_EMAIL,
+  await transporter.sendMail({
+    from: GMAIL_EMAIL,
+    to: GMAIL_EMAIL,
     subject: "My Site Contact Form",
     html: `<p>Hello,<p><br><p>You received a message with the following information: </p><ul><li>First Name: ${firstName}</li><li>Last Name: ${lastName}</li><li>Email: ${email}</li><li>Phone: ${phone}</li><li>Message: ${message}</li></ul>`,
   });
-  console.log("Message sent: %s", info.messageId);
+
   return NextResponse.json(
     {
       message:

--- a/src/app/components/Contact/__snapshots__/index.test.tsx.snap
+++ b/src/app/components/Contact/__snapshots__/index.test.tsx.snap
@@ -138,6 +138,7 @@ exports[`<Contact/> Test Suite should render the <Contact/> component unchanged 
             name="firstName"
             required=""
             type="text"
+            value=""
           />
           <label
             class="InputLabel"
@@ -151,6 +152,7 @@ exports[`<Contact/> Test Suite should render the <Contact/> component unchanged 
             name="lastName"
             required=""
             type="text"
+            value=""
           />
           <label
             class="InputLabel"
@@ -164,6 +166,7 @@ exports[`<Contact/> Test Suite should render the <Contact/> component unchanged 
             name="email"
             required=""
             type="email"
+            value=""
           />
           <label
             class="InputLabel"
@@ -176,6 +179,7 @@ exports[`<Contact/> Test Suite should render the <Contact/> component unchanged 
             id="phone"
             name="phone"
             type="text"
+            value=""
           />
           <label
             class="InputLabel"

--- a/src/app/components/Contact/index.module.scss
+++ b/src/app/components/Contact/index.module.scss
@@ -89,6 +89,12 @@
   color: $secondary-color;
   height: 2rem;
   background-color: $text-color;
+
+  &:hover {
+    background-color: transparent;
+    color: $text-color;
+    border: 1px solid $text-color;
+  }
 }
 
 .TextHeading {

--- a/src/app/components/Contact/index.test.tsx
+++ b/src/app/components/Contact/index.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import Contact from "./index";

--- a/src/app/components/Contact/index.test.tsx
+++ b/src/app/components/Contact/index.test.tsx
@@ -6,66 +6,172 @@ import Contact from "./index";
 describe("<Contact/> Test Suite", () => {
   it("should render the <Contact/> component unchanged", () => {
     const handleSendEmail = jest.fn();
-    const { container } = render(<Contact handleSendEmail={handleSendEmail} />);
+    const firstName = "";
+    const setFirstName = jest.fn();
+    const lastName = "";
+    const setLastName = jest.fn();
+    const email = "";
+    const setEmail = jest.fn();
+    const phone = "";
+    const setPhone = jest.fn();
+    const message = "";
+    const setMessage = jest.fn();
+    const { container } = render(
+      <Contact
+        handleSendEmail={handleSendEmail}
+        firstName={firstName}
+        setFirstName={setFirstName}
+        lastName={lastName}
+        setLastName={setLastName}
+        email={email}
+        setEmail={setEmail}
+        phone={phone}
+        setPhone={setPhone}
+        message={message}
+        setMessage={setMessage}
+      />,
+    );
     expect(container).toMatchSnapshot();
   });
 
   it("should contain the Contact heading in the <Contact/> component", () => {
     const handleSendEmail = jest.fn();
-    render(<Contact handleSendEmail={handleSendEmail} />);
+    const firstName = "";
+    const setFirstName = jest.fn();
+    const lastName = "";
+    const setLastName = jest.fn();
+    const email = "";
+    const setEmail = jest.fn();
+    const phone = "";
+    const setPhone = jest.fn();
+    const message = "";
+    const setMessage = jest.fn();
+    render(
+      <Contact
+        handleSendEmail={handleSendEmail}
+        firstName={firstName}
+        setFirstName={setFirstName}
+        lastName={lastName}
+        setLastName={setLastName}
+        email={email}
+        setEmail={setEmail}
+        phone={phone}
+        setPhone={setPhone}
+        message={message}
+        setMessage={setMessage}
+      />,
+    );
     const heading = screen.getByText("Contact");
     expect(heading).toBeInTheDocument();
   });
 
   it("should contain all the required input fields in the <Contact/> component", () => {
     const handleSendEmail = jest.fn();
-    render(<Contact handleSendEmail={handleSendEmail} />);
-    const firstName = screen.getByLabelText("First Name");
-    const lastName = screen.getByLabelText("Last Name");
-    const email = screen.getByLabelText("Email");
-    const phone = screen.getByLabelText("Phone");
-    const message = screen.getByLabelText("Message");
-    expect(firstName).toBeInTheDocument();
-    expect(lastName).toBeInTheDocument();
-    expect(email).toBeInTheDocument();
-    expect(phone).toBeInTheDocument();
-    expect(message).toBeInTheDocument();
+    const firstName = "";
+    const setFirstName = jest.fn();
+    const lastName = "";
+    const setLastName = jest.fn();
+    const email = "";
+    const setEmail = jest.fn();
+    const phone = "";
+    const setPhone = jest.fn();
+    const message = "";
+    const setMessage = jest.fn();
+    render(
+      <Contact
+        handleSendEmail={handleSendEmail}
+        firstName={firstName}
+        setFirstName={setFirstName}
+        lastName={lastName}
+        setLastName={setLastName}
+        email={email}
+        setEmail={setEmail}
+        phone={phone}
+        setPhone={setPhone}
+        message={message}
+        setMessage={setMessage}
+      />,
+    );
+    const firstNameInput = screen.getByLabelText("First Name");
+    const lastNameInput = screen.getByLabelText("Last Name");
+    const emailInput = screen.getByLabelText("Email");
+    const phoneInput = screen.getByLabelText("Phone");
+    const messageInput = screen.getByLabelText("Message");
+    expect(firstNameInput).toBeInTheDocument();
+    expect(lastNameInput).toBeInTheDocument();
+    expect(emailInput).toBeInTheDocument();
+    expect(phoneInput).toBeInTheDocument();
+    expect(messageInput).toBeInTheDocument();
   });
 
   it("should fill the all the required form input fields in the <Contact/> component", () => {
     const handleSendEmail = jest.fn();
-    render(<Contact handleSendEmail={handleSendEmail} />);
-    const firstName = screen.getByRole("textbox", { name: "First Name" });
-    const lastName = screen.getByRole("textbox", { name: "Last Name" });
-    const email = screen.getByRole("textbox", { name: "Email" });
-    const phone = screen.getByRole("textbox", { name: "Phone" });
-    const message = screen.getByRole("textbox", { name: "Message" });
-    fireEvent.change(firstName, { target: { value: "John" } });
-    fireEvent.change(lastName, { target: { value: "Doe" } });
-    fireEvent.change(email, { target: { value: "jdoe@test.com" } });
-    fireEvent.change(phone, { target: { value: "555-555-5555" } });
-    fireEvent.change(message, { target: { value: "This is a test message." } });
-    expect(firstName).toHaveValue("John");
-    expect(lastName).toHaveValue("Doe");
-    expect(email).toHaveValue("jdoe@test.com");
-    expect(phone).toHaveValue("555-555-5555");
-    expect(message).toHaveValue("This is a test message.");
+    const firstName = "John";
+    const setFirstName = jest.fn();
+    const lastName = "Doe";
+    const setLastName = jest.fn();
+    const email = "jdoe@test.com";
+    const setEmail = jest.fn();
+    const phone = "555-555-5555";
+    const setPhone = jest.fn();
+    const message = "This is a test message.";
+    const setMessage = jest.fn();
+    render(
+      <Contact
+        handleSendEmail={handleSendEmail}
+        firstName={firstName}
+        setFirstName={setFirstName}
+        lastName={lastName}
+        setLastName={setLastName}
+        email={email}
+        setEmail={setEmail}
+        phone={phone}
+        setPhone={setPhone}
+        message={message}
+        setMessage={setMessage}
+      />,
+    );
+    const firstNameInput = screen.getByRole("textbox", { name: "First Name" });
+    const lastNameInput = screen.getByRole("textbox", { name: "Last Name" });
+    const emailInput = screen.getByRole("textbox", { name: "Email" });
+    const phoneInput = screen.getByRole("textbox", { name: "Phone" });
+    const messageInput = screen.getByRole("textbox", { name: "Message" });
+
+    expect(firstNameInput).toHaveValue("John");
+    expect(lastNameInput).toHaveValue("Doe");
+    expect(emailInput).toHaveValue("jdoe@test.com");
+    expect(phoneInput).toHaveValue("555-555-5555");
+    expect(messageInput).toHaveValue("This is a test message.");
   });
 
   it("should execute the sendEmail function in the <Contact/> component", async () => {
-    const handleSendEmail = jest.fn((event) => event.preventDefault());
     const user = userEvent.setup();
-    render(<Contact handleSendEmail={handleSendEmail} />);
-    const firstName = screen.getByRole("textbox", { name: "First Name" });
-    const lastName = screen.getByRole("textbox", { name: "Last Name" });
-    const email = screen.getByRole("textbox", { name: "Email" });
-    const phone = screen.getByRole("textbox", { name: "Phone" });
-    const message = screen.getByRole("textbox", { name: "Message" });
-    fireEvent.change(firstName, { target: { value: "John" } });
-    fireEvent.change(lastName, { target: { value: "Doe" } });
-    fireEvent.change(email, { target: { value: "jdoe@test.com" } });
-    fireEvent.change(phone, { target: { value: "555-555-5555" } });
-    fireEvent.change(message, { target: { value: "This is a test message." } });
+    const handleSendEmail = jest.fn((event) => event.preventDefault());
+    const firstName = "John";
+    const setFirstName = jest.fn();
+    const lastName = "Doe";
+    const setLastName = jest.fn();
+    const email = "jdoe@test.com";
+    const setEmail = jest.fn();
+    const phone = "555-555-5555";
+    const setPhone = jest.fn();
+    const message = "This is a test message.";
+    const setMessage = jest.fn();
+    render(
+      <Contact
+        handleSendEmail={handleSendEmail}
+        firstName={firstName}
+        setFirstName={setFirstName}
+        lastName={lastName}
+        setLastName={setLastName}
+        email={email}
+        setEmail={setEmail}
+        phone={phone}
+        setPhone={setPhone}
+        message={message}
+        setMessage={setMessage}
+      />,
+    );
 
     const submit = screen.getByRole("button", { name: "Submit" });
     await user.click(submit);

--- a/src/app/components/Contact/index.tsx
+++ b/src/app/components/Contact/index.tsx
@@ -1,6 +1,6 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import styles from "./index.module.scss";
-import { FormEvent, useState } from "react";
+import { FormEvent } from "react";
 import Link from "next/link";
 import {
   faFacebook,

--- a/src/app/components/Contact/index.tsx
+++ b/src/app/components/Contact/index.tsx
@@ -1,6 +1,6 @@
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import styles from "./index.module.scss";
-import { FormEvent } from "react";
+import { FormEvent, useState } from "react";
 import Link from "next/link";
 import {
   faFacebook,
@@ -8,13 +8,34 @@ import {
   faLinkedin,
   faXTwitter,
 } from "@fortawesome/free-brands-svg-icons";
-import { faX } from "@fortawesome/free-solid-svg-icons";
 
 type Props = {
   handleSendEmail: (event: FormEvent<HTMLFormElement>) => void;
+  firstName: string;
+  setFirstName: (value: string) => void;
+  lastName: string;
+  setLastName: (value: string) => void;
+  email: string;
+  setEmail: (value: string) => void;
+  phone: string;
+  setPhone: (value: string) => void;
+  message: string;
+  setMessage: (value: string) => void;
 };
 
-const Contact = ({ handleSendEmail }: Props) => {
+const Contact = ({
+  handleSendEmail,
+  firstName,
+  setFirstName,
+  lastName,
+  setLastName,
+  email,
+  setEmail,
+  phone,
+  setPhone,
+  message,
+  setMessage,
+}: Props) => {
   return (
     <section id={"contact"} className={styles.Contact}>
       <h1 className={styles.TextHeading}>Contact</h1>
@@ -57,6 +78,8 @@ const Contact = ({ handleSendEmail }: Props) => {
               name="firstName"
               required={true}
               type="text"
+              value={firstName}
+              onChange={(event) => setFirstName(event.target.value)}
             />
             <label htmlFor="lastName" className={styles.InputLabel}>
               Last Name
@@ -67,6 +90,8 @@ const Contact = ({ handleSendEmail }: Props) => {
               name="lastName"
               required={true}
               type="text"
+              value={lastName}
+              onChange={(event) => setLastName(event.target.value)}
             />
             <label htmlFor="email" className={styles.InputLabel}>
               Email
@@ -77,6 +102,8 @@ const Contact = ({ handleSendEmail }: Props) => {
               name="email"
               required={true}
               type="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
             />
             <label htmlFor="phone" className={styles.InputLabel}>
               Phone
@@ -86,6 +113,8 @@ const Contact = ({ handleSendEmail }: Props) => {
               id="phone"
               name="phone"
               type="text"
+              value={phone}
+              onChange={(event) => setPhone(event.target.value)}
             />
             <label htmlFor="message" className={styles.InputLabel}>
               Message
@@ -95,6 +124,8 @@ const Contact = ({ handleSendEmail }: Props) => {
               id="message"
               name="message"
               required={true}
+              value={message}
+              onChange={(event) => setMessage(event.target.value)}
             />
             <button className={styles.SubmitButton} type="submit">
               Submit

--- a/src/app/lib/nodemailer/nodemailerConfig.js
+++ b/src/app/lib/nodemailer/nodemailerConfig.js
@@ -1,14 +1,18 @@
 import nodemailer from "nodemailer";
+import {
+  GMAIL_SMTP_SERVER,
+  GMAIL_SMTP_SERVER_PORT,
+  GMAIL_EMAIL,
+  GMAIL_APP_PASSWORD,
+} from "../../utils/constants";
 
 export const transporter = nodemailer.createTransport({
-  host: process.env.OUTLOOK_SMTP_SERVER,
-  port: process.env.OUTLOOK_SMTP_SERVER_PORT,
-  tls: {
-    ciphers: "SSLv3",
-    rejectUnauthorized: false,
-  },
+  service: "gmail",
+  host: GMAIL_SMTP_SERVER,
+  port: GMAIL_SMTP_SERVER_PORT,
+  secure: true,
   auth: {
-    user: process.env.OUTLOOK_EMAIL,
-    pass: process.env.OUTLOOK_APP_PASSWORD,
+    user: GMAIL_EMAIL,
+    pass: GMAIL_APP_PASSWORD,
   },
 });

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,20 +4,28 @@ import styles from "./page.module.scss";
 import Header from "./components/Header";
 import About from "./components/About";
 import Experience from "./components/Experience";
-import { FormEvent } from "react";
+import { FormEvent, useState } from "react";
 import Contact from "./components/Contact";
 
 const Home = () => {
+  const [firstName, setFirstName] = useState("");
+  const [lastName, setLastName] = useState("");
+  const [email, setEmail] = useState("");
+  const [phone, setPhone] = useState("");
+  const [message, setMessage] = useState("");
+
   const handleSendEmail = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const formData = new FormData(event.currentTarget);
-    const response = await fetch("/api/email", {
+    await fetch("/api/email", {
       method: "POST",
       body: formData,
     });
-    if (response.ok) {
-      (document.getElementById("SubmitForm") as HTMLFormElement)?.reset();
-    }
+    setFirstName("");
+    setLastName("");
+    setEmail("");
+    setPhone("");
+    setMessage("");
   };
 
   return (
@@ -25,7 +33,19 @@ const Home = () => {
       <Header />
       <About />
       <Experience />
-      <Contact handleSendEmail={handleSendEmail} />
+      <Contact
+        handleSendEmail={handleSendEmail}
+        firstName={firstName}
+        setFirstName={setFirstName}
+        lastName={lastName}
+        setLastName={setLastName}
+        email={email}
+        setEmail={setEmail}
+        phone={phone}
+        setPhone={setPhone}
+        message={message}
+        setMessage={setMessage}
+      />
       <section className={styles.Copyright}>
         <div>Made with ❤️ by Jean-Frederic Mainville</div>
       </section>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,13 +14,14 @@ const Home = () => {
   const [phone, setPhone] = useState("");
   const [message, setMessage] = useState("");
 
-  const handleSendEmail = async (event: FormEvent<HTMLFormElement>) => {
+  const handleSendEmail = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const formData = new FormData(event.currentTarget);
-    await fetch("/api/email", {
+    fetch("/api/email", {
       method: "POST",
       body: formData,
     });
+
     setFirstName("");
     setLastName("");
     setEmail("");

--- a/src/app/utils/constants.ts
+++ b/src/app/utils/constants.ts
@@ -6,3 +6,9 @@ export const PORT = process.env.PORT || "3000";
 export const MY_SITE_URL =
   process.env.MY_SITE_URL || `http://localhost:${PORT}`;
 export const RESUME_FILENAME = "Resume_Jean_Frederic_Mainville.pdf";
+export const GMAIL_SMTP_SERVER =
+  process.env.GMAIL_SMTP_SERVER || "smtp.gmail.com";
+export const GMAIL_SMTP_SERVER_PORT =
+  process.env.GMAIL_SMTP_SERVER_PORT || "587";
+export const GMAIL_EMAIL = process.env.GMAIL_EMAIL;
+export const GMAIL_APP_PASSWORD = process.env.GMAIL_APP_PASSWORD;


### PR DESCRIPTION
# Changes

- Replace the Outlook SMTP server with the Gmail SMTP server
- Update the contact form state management configuration to use the `value` and `onChange` attributes
- Remove the `await` method for the email sending API call
- Update the `README.md` file environment variables section
- Update the `container-apps-deploy.yml` GitHub Actions configuration to include the Gmail specific environment variables
- Add the `hover` style to the contact form submit button to improve the UX

# Additional Notes

- The Outlook SMTP server basic authentication using an App password is being disabled for personal accounts which means that it needs to be replaced
- The Gmail SMTP server use the same mechanism, so it was use as replacement