### PR TITLE
NUA-54: Add the no-console rule to the .eslintrc.json file

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,6 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": "next/core-web-vitals",
+  "rules": {
+    "no-console": "warn"
+  }
 }


### PR DESCRIPTION
# Changes

- Add the `no-console` rule to the `.eslintrc.json` file to show a warning if `console.log` statements are present in the code base