### PR TITLE
NUA-107: Add the `poweredByHeader` attribute to the `next.config.mjs` file

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,6 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  poweredByHeader: false,
+};
 
 export default nextConfig;


### PR DESCRIPTION
# Changes

- Add the `poweredByHeader` attribute to the `next.config.mjs` file

# Additional Notes

- By default, Next.js appends an `X-Powered-By` HTTP header to all the requests made to the application. This provides useful information about the programming language and framework being used by the web application
- This HTTP header should be removed to prevent threat actors from having this information