### PR TITLE
HOTFIX: Fix the typescript error by validating that the `editor` attribute exists

### DIFF
--- a/src/app/components/Writer/index.tsx
+++ b/src/app/components/Writer/index.tsx
@@ -141,7 +141,7 @@ const Writer = ({ postData }: any) => {
   const addImage = useCallback(() => {
     const url = window.prompt("URL");
 
-    if (url) {
+    if (url && editor) {
       editor.chain().focus().setImage({ src: url }).run();
     }
   }, [editor]);


### PR DESCRIPTION
# Changes

- Fix the typescript error by validating that the `editor` attribute exists in the `Writer` component