### PR TITLE
NUA-129: Fix the `DATABASE_URL` environment variable definition during the docker build execution 

### DIFF
--- a/src/app/admin/post/page.tsx
+++ b/src/app/admin/post/page.tsx
@@ -6,6 +6,8 @@ import { getPosts } from "../../lib/db";
 import Button from "@/app/components/Button";
 import Image from "next/image";
 
+export const dynamic = "force-dynamic";
+
 export type PostData = {
   postStatus: String;
   postTitle: String;


### PR DESCRIPTION
# Changes

- Add the `export const dynamic = "force-dynamic"` constant to the `/app/admin/post/page.tsx` file

# Additional Notes

- This constant is required to prevent loading the Prisma schema while building the Docker image which doesn't have access to the database server