### PR TITLE
NUA-132: Use the Ubuntu 24.04 Docker image for all GitHub Actions jobs

### DIFF
--- a/.github/workflows/container-apps-deploy.yml
+++ b/.github/workflows/container-apps-deploy.yml
@@ -8,7 +8,7 @@ permissions:
   contents: read
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: production
     steps:
       - name: Checkout the current git repository
@@ -26,7 +26,7 @@ jobs:
           docker push ${{ vars.AZURE_ACR_URL }}/my-site:latest
           docker push ${{ vars.AZURE_ACR_URL }}/my-site:${{ github.SHA }}
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: production
     steps:
       - name: Checkout the current git repository

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -7,7 +7,7 @@ on:
       - reopened
 jobs:
   typescript:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout the current git repository
         uses: actions/checkout@main
@@ -17,7 +17,7 @@ jobs:
           npm ci
           npm run type-check
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: production
     steps:
       - name: Checkout the current git repository
@@ -28,7 +28,7 @@ jobs:
           npm ci
           npm run lint
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: production
     steps:
       - name: Checkout the current git repository


### PR DESCRIPTION
# Changes

- Update the Ubuntu Docker image to vesion `24.04` instead of `latest` to remove a warning that would show up on every run