### PR TITLE
PER-53: Update the `NEXT_PUBLIC_AWS_BUCKET_URL` environment variable definition

### DIFF
--- a/kubernetes/base/deployment.yaml
+++ b/kubernetes/base/deployment.yaml
@@ -40,7 +40,7 @@ spec:
                   name: my-site-secret
                   key: GMAIL_APP_PASSWORD
             - name: NEXT_PUBLIC_AWS_BUCKET_URL
-              value: https://nuagir-sbs-my-site-usea1-prod.s3.us-east-1.amazonaws.com
+              value: https://nuagir-my-site-sbs-usea1-prod.s3.us-east-1.amazonaws.com
             - name: DATABASE_URL
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
# Changes

- Update the `NEXT_PUBLIC_AWS_BUCKET_URL` environment variable definition to point to the new AWS S3 bucket resource

# Additional Notes

- The S3 bucket name change was caused by a standardization of the naming convention for AWS resouces