### PR TITLE
NUA-416 feat(kubernetes): add `certificate` and `http-route` Kubernetres resources for Let's Encrypt TLS and HTTP routing

### DIFF
--- a/kubernetes/base/certificate.yaml
+++ b/kubernetes/base/certificate.yaml
@@ -1,0 +1,11 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: letsencrypt-certificate
+spec:
+  secretName: my-site-tls-secret
+  dnsNames:
+    - jfmainville.me
+  issuerRef:
+    name: letsencrypt-gateway-cluster-issuer
+    kind: ClusterIssuer

--- a/kubernetes/base/http-route.yaml
+++ b/kubernetes/base/http-route.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: http-route
+spec:
+  parentRefs:
+    - name: nuagir-gateway-service
+  hostnames:
+    - "jfmainville.me"
+  rules:
+    - matches:
+        - path:
+            value: /
+      backendRefs:
+        - name: my-site-cip-service
+          port: 3000

--- a/kubernetes/base/kustomization.yaml
+++ b/kubernetes/base/kustomization.yaml
@@ -2,7 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namePrefix: my-site-
 resources:
+  - certificate.yaml
   - deployment.yaml
+  - http-route.yaml
   - service.yaml
 labels:
 - includeSelectors: true

--- a/kubernetes/production/certificate.yaml
+++ b/kubernetes/production/certificate.yaml
@@ -1,0 +1,11 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: letsencrypt-certificate
+spec:
+  secretName: my-site-tls-secret
+  dnsNames:
+    - jfmainville.me
+  issuerRef:
+    name: letsencrypt-gateway-cluster-issuer
+    kind: ClusterIssuer

--- a/kubernetes/production/http-route.yaml
+++ b/kubernetes/production/http-route.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: http-route
+spec:
+  parentRefs:
+    - name: nuagir-gateway-service
+  hostnames:
+    - "jfmainville.me"
+  rules:
+    - matches:
+        - path:
+            value: /
+      backendRefs:
+        - name: my-site-cip-service
+          port: 3000

--- a/kubernetes/production/kustomization.yaml
+++ b/kubernetes/production/kustomization.yaml
@@ -11,4 +11,6 @@ labels:
     pairs:
       env: production
 patches:
+  - path: certificate.yaml
   - path: deployment.yaml
+  - path: http-route.yaml


### PR DESCRIPTION
## Changes

- Added `Certificate` resource for Let's Encrypt in both `base` and `production` Kubernetes environments
- Added `HTTPRoute` resource for HTTP routing in both `base` and `production` Kubernetes environments
- Updated `kustomization.yaml` in `base` environment to include `certificate.yaml` and `http-route.yaml` resources
- Updated `kustomization.yaml` in `production` environment to include `certificate.yaml` and `http-route.yaml` as patches

## Additional Notes

- The new `Certificate` resource enables TLS using Let's Encrypt by referencing `ClusterIssuer` `letsencrypt-gateway-cluster-issuer`
- `HTTPRoute` provides HTTP routing capability via the gateway and routes traffic to the correct backend service
- The configuration was tested and it's working properly